### PR TITLE
Adding argument for detailed logit analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install accelerate
 | `--output-path`   | `output-path.json` | Where to store the output results. |
 | `--num-gpus`      | `1` | Number of GPUs to use |
 | `--max_gpu_memory`| `27` | Maximum GPU memory size (in GiB) to allocate. Default: 27 (for 32G V100).  |
+| `--print-logits`| | Adding this argument prints the top 5 logits in the premature layers for each token generated |
 
 ### Understanding `--early-exit-layers`
 

--- a/dola_t5.py
+++ b/dola_t5.py
@@ -87,7 +87,7 @@ class DoLa:
                 outputs = self.model.generate(input_ids, max_length=max_len, num_return_sequences=1,
                                         output_scores=True, return_dict_in_generate=True, dola_decoding=True,
                                         top_p=top_p, top_k=top_k, temperature=temperature, stopping_criteria=self.stopping_criteria, relative_top=relative_top, 
-                                        mature_layer=mature_layer, premature_layer=None, candidate_premature_layers=candidate_premature_layers, **kwargs,)
+                                        mature_layer=mature_layer, premature_layer=None, candidate_premature_layers=candidate_premature_layers, print_logits=print_logits, **kwargs,)
                 premature_layer_dist = outputs.premature_layer_dist
             sequences, scores = outputs.sequences, outputs.scores
             js_divs, logits_by_layer = outputs.js_divs, outputs.logits_by_layer

--- a/transformers-4.28.1/src/transformers/generation/utils.py
+++ b/transformers-4.28.1/src/transformers/generation/utils.py
@@ -1139,6 +1139,7 @@ class GenerationMixin:
         contrastive_decoding: Optional[bool] = None,
         student_model = None,
         streamer: Optional["BaseStreamer"] = None,
+        print_logits: Optional[bool] = None,
         **kwargs,
     ) -> Union[GenerateOutput, torch.LongTensor]:
         r"""
@@ -1465,6 +1466,7 @@ class GenerationMixin:
                 candidate_premature_layers=candidate_premature_layers,
                 relative_top=relative_top,
                 streamer=streamer,
+                output_jsd_and_logits= print_logits,
                 **model_kwargs,
             )
 
@@ -2487,7 +2489,7 @@ class GenerationMixin:
         return_dict_in_generate: Optional[bool] = None,
         synced_gpus: Optional[bool] = False,
         streamer: Optional["BaseStreamer"] = None,
-        output_jsd_and_logits: Optional[bool] = True,
+        output_jsd_and_logits: Optional[bool] = False,
         **model_kwargs,
     ) -> Union[GreedySearchOutput, torch.LongTensor]:
         r"""


### PR DESCRIPTION
This PR adds the ability to print detailed logit information per token by passing in a `--print-logit` argument to the ifeval script. For each token generated, the following are printed:
- the top 5 tokens for each early exit layer, along with their logits
- the indices of the top 5 output tokens in the early exit layers (sorted in descending order by logit)